### PR TITLE
4 enhance redis connectivity options

### DIFF
--- a/example/apollo/index.ts
+++ b/example/apollo/index.ts
@@ -1,15 +1,15 @@
-import { schemaWithIoRedis } from './../schema/schema';
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
 import express from 'express';
 import http from 'http';
+import { schemaWithRedisUrl } from '../schema/schema';
 
 const startServer = async () => {
   const app = express();
   const httpServer = http.createServer(app);
 
-  const schema = await schemaWithIoRedis();
+  const schema = await schemaWithRedisUrl();
 
   const server = new ApolloServer({
     schema,

--- a/src/cache/redisCache.ts
+++ b/src/cache/redisCache.ts
@@ -1,72 +1,64 @@
 import { ICache } from './ICache';
-import { RedisClientType } from 'redis';
-import { Redis as IORedisClient } from 'ioredis';
+import { Redis, Cluster, RedisOptions } from 'ioredis';
 
-type RedisClient = RedisClientType | IORedisClient;
+type RedisClient = Redis | Cluster;
 
 export class RedisCache implements ICache {
   private readonly client: RedisClient;
   private readonly keyPrefix: string = 'gql-depth-guard::';
   private readonly ttl: number;
+  private readonly disconnectRequired: boolean;
 
-  constructor(client: RedisClient, ttl?: number) {
-    this.client = client;
-    this.ttl = ttl ?? 60000;
+  constructor(client: Redis);
+  constructor(cluster: Cluster);
+  constructor(options: RedisOptions);
+  constructor(url: string);
+  constructor(redisOrOptions?: Redis | Cluster | RedisOptions | string) {
+    if (redisOrOptions instanceof Redis || redisOrOptions instanceof Cluster) {
+      // Instance injected from outside, lifecycle should be managed externally
+      this.client = redisOrOptions;
+      this.disconnectRequired = false;
+    } else if (typeof redisOrOptions === 'string') {
+      // New Redis instance created internally, lifecycle managed by RedisCache
+      this.client = new Redis(redisOrOptions);
+      this.disconnectRequired = true;
+    } else {
+      // New Redis instance created internally, lifecycle managed by RedisCache
+      this.client = new Redis(redisOrOptions as RedisOptions);
+      this.disconnectRequired = true;
+    }
+    this.ttl = 60000;
   }
 
   async set(key: string, value: number): Promise<void> {
     const fullKey = this.generateKey(key);
     const serializedValue = JSON.stringify(value);
 
-    if (this.isIORedisClient()) {
-      await (this.client as IORedisClient).set(
-        fullKey,
-        serializedValue,
-        'PX',
-        this.ttl,
-      );
-    } else {
-      await (this.client as RedisClientType).set(fullKey, serializedValue, {
-        PX: this.ttl,
-      });
-    }
+    await this.client.set(fullKey, serializedValue, 'PX', this.ttl);
   }
 
   async get(key: string): Promise<number | null> {
     const fullKey = this.generateKey(key);
-    let serializedValue: string | null;
-
-    if (this.isIORedisClient()) {
-      serializedValue = await (this.client as IORedisClient).get(fullKey);
-    } else {
-      serializedValue = await (this.client as RedisClientType).get(fullKey);
-    }
+    const serializedValue = await this.client.get(fullKey);
 
     if (serializedValue === null) return null;
     return JSON.parse(serializedValue) as number;
   }
 
   async clear(): Promise<void> {
-    if (this.isIORedisClient()) {
-      await (this.client as IORedisClient).flushall();
-    } else {
-      await (this.client as RedisClientType).flushAll();
+    await this.client.flushall();
+  }
+
+  /**
+   * Disconnects from Redis if the connection was created by this instance
+   */
+  onDestroy(): void {
+    if (this.disconnectRequired) {
+      this.client.disconnect();
     }
   }
 
   private generateKey(key: string): string {
     return `${this.keyPrefix}${key}`;
-  }
-
-  /**
-   * Checks if the client is an ioredis client.
-   * @returns True if the client is ioredis, otherwise false.
-   */
-  private isIORedisClient(): boolean {
-    return (
-      typeof (this.client as IORedisClient).set === 'function' &&
-      typeof (this.client as IORedisClient).get === 'function' &&
-      typeof (this.client as IORedisClient).flushall === 'function'
-    );
   }
 }

--- a/src/cache/redisCache.ts
+++ b/src/cache/redisCache.ts
@@ -9,11 +9,14 @@ export class RedisCache implements ICache {
   private readonly ttl: number;
   private readonly disconnectRequired: boolean;
 
-  constructor(client: Redis);
-  constructor(cluster: Cluster);
-  constructor(options: RedisOptions);
-  constructor(url: string);
-  constructor(redisOrOptions?: Redis | Cluster | RedisOptions | string) {
+  constructor(client: Redis, ttl?: number);
+  constructor(cluster: Cluster, ttl?: number);
+  constructor(options: RedisOptions, ttl?: number);
+  constructor(url: string, ttl?: number);
+  constructor(
+    redisOrOptions: Redis | Cluster | RedisOptions | string,
+    ttl: number = 60000, // Default TTL: 1 minute
+  ) {
     if (redisOrOptions instanceof Redis || redisOrOptions instanceof Cluster) {
       // Instance injected from outside, lifecycle should be managed externally
       this.client = redisOrOptions;
@@ -27,7 +30,7 @@ export class RedisCache implements ICache {
       this.client = new Redis(redisOrOptions as RedisOptions);
       this.disconnectRequired = true;
     }
-    this.ttl = 60000;
+    this.ttl = ttl;
   }
 
   async set(key: string, value: number): Promise<void> {


### PR DESCRIPTION
## Description

Currently, our RedisCache implementation only accepts a pre-configured Redis client object. This PR adds support for multiple connection methods to improve flexibility and ease of use.

Key improvements include:
- Support for Redis URL connection strings (e.g., 'redis://localhost:6379')
- Support for Redis configuration objects with host, port, and password options
- Support for Redis Cluster configurations
- Automatic connection lifecycle management for internally created Redis clients
- Optional TTL configuration for cached depth calculations (default: 60000ms)

Fixes #4 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause
- [X] This change requires a documentation update